### PR TITLE
Only request enough permission from the user to allow authentication - #4

### DIFF
--- a/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
+++ b/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
@@ -209,7 +209,7 @@ public class OAuthLoginPlugin implements GoPlugin {
             socialAuthConfiguration.load(oauthConsumerProperties);
             SocialAuthManager manager = new SocialAuthManager();
             manager.setSocialAuthConfig(socialAuthConfiguration);
-            String redirectURL = manager.getAuthenticationUrl(provider.getProviderName(), getURL(pluginSettings.getServerBaseURL()), Permission.ALL);
+            String redirectURL = manager.getAuthenticationUrl(provider.getProviderName(), getURL(pluginSettings.getServerBaseURL()), Permission.AUTHENTICATE_ONLY);
 
             store(manager);
 


### PR DESCRIPTION
In the github case, `Permission.ALL` and `Permission.AUTHENTICATE_ONLY` are
the same thing:
https://github.com/3pillarlabs/socialauth/blob/d42b866a6e21618b50a9888d423a60379fa9f980/socialauth/src/main/java/org/brickred/socialauth/provider/GitHubImpl.java#L73

In the google case, `Permission.ALL` requires that the user create a
google+ profile. `Permission.AUTHENTICATE_ONLY` does not, but still
provides access to email, display name, etc:
https://github.com/3pillarlabs/socialauth/blob/d42b866a6e21618b50a9888d423a60379fa9f980/socialauth/src/main/java/org/brickred/socialauth/provider/GooglePlusImpl.java#L84

See: https://github.com/srinivasupadhya/gocd-oauth-login/issues/4
