### PR TITLE
Add regex-checking on username before authorizing as gocd user - #5

### DIFF
--- a/src/main/java/com/tw/go/plugin/PluginSettings.java
+++ b/src/main/java/com/tw/go/plugin/PluginSettings.java
@@ -1,5 +1,7 @@
 package com.tw.go.plugin;
 
+import java.util.regex.Pattern;
+
 public class PluginSettings {
     private String serverBaseURL;
     private String consumerKey;
@@ -7,14 +9,16 @@ public class PluginSettings {
     private String username;
     private String password;
     private String oauthToken;
+    private String usernameRegex;
 
-    public PluginSettings(String serverBaseURL, String consumerKey, String consumerSecret, String username, String password, String oauthToken) {
+    public PluginSettings(String serverBaseURL, String consumerKey, String consumerSecret, String username, String password, String oauthToken, String usernameRegex) {
         this.serverBaseURL = serverBaseURL;
         this.consumerKey = consumerKey;
         this.consumerSecret = consumerSecret;
         this.username = username;
         this.password = password;
         this.oauthToken = oauthToken;
+        setUsernameRegex(usernameRegex);
     }
 
     public String getServerBaseURL() {
@@ -63,6 +67,18 @@ public class PluginSettings {
 
     public void setOauthToken(String oauthToken) {
         this.oauthToken = oauthToken;
+    }
+
+    public String getUsernameRegex() {
+        return usernameRegex;
+    }
+
+    public void setUsernameRegex(String usernameRegex) {
+        if (isEmpty(usernameRegex)) {
+            this.usernameRegex = "";
+        } else {
+            this.usernameRegex = usernameRegex;
+        }
     }
 
     public boolean containsUsernameAndPassword() {

--- a/src/main/resources/common/plugin-settings.template.html
+++ b/src/main/resources/common/plugin-settings.template.html
@@ -28,3 +28,8 @@
     <input type="password" ng-model="oauth_token" ng-required="true"/>
     <span class="form_error" ng-show="GOINPUTNAME[oauth_token].$error.server">{{ GOINPUTNAME[oauth_token].$error.server }}</span>
 </div>
+<div class="form_item_block">
+    <label>Username Regular Expression:</label>
+    <input type="text" ng-model="username_regex" ng-required="true"/>
+    <span class="form_error" ng-show="GOINPUTNAME[username_regex].$error.server">{{ GOINPUTNAME[username_regex].$error.server }}</span>
+</div>


### PR DESCRIPTION
This is so that you can limit which users are authorized to log into
GoCD via some regex.

Eg, you could limit by google apps domain, using `.*@foo.com$` as the
regex, or you could limit by github username, using `^userfoo$|^userbar$`.

See: #5 
