### PR TITLE
Fix libraries folder name on non windows environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.outputDirectory}\lib</outputDirectory>
+                            <outputDirectory>${project.build.outputDirectory}${file.separator}lib</outputDirectory>
                             <includeScope>runtime</includeScope>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>


### PR DESCRIPTION
I was trying to build locally on MacOS and there was no libs inside the generated jar file.
This PR fix the dir name for libraries and should work on Windows, Mac and Linux.
