### PR TITLE
Fixes for github auth scope and display name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tw.go.plugin</groupId>
     <artifactId>gocd-oauth-login</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
+++ b/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
@@ -207,12 +207,17 @@ public class OAuthLoginPlugin implements GoPlugin {
             Properties oauthConsumerProperties = new Properties();
             oauthConsumerProperties.put(provider.getConsumerKeyPropertyName(), pluginSettings.getConsumerKey());
             oauthConsumerProperties.put(provider.getConsumerSecretPropertyName(), pluginSettings.getConsumerSecret());
+            String scopeprop = provider.getAuthScopePropertyName();
+            Permission perm = Permission.AUTHENTICATE_ONLY;
+            if ( scopeprop != null && scopeprop.length() > 0 ) {
+                perm = Permission.CUSTOM;
+                oauthConsumerProperties.put(provider.getAuthScopePropertyName(), provider.getAuthScopePropertyValue());
+            }
             SocialAuthConfig socialAuthConfiguration = SocialAuthConfig.getDefault();
             socialAuthConfiguration.load(oauthConsumerProperties);
             SocialAuthManager manager = new SocialAuthManager();
             manager.setSocialAuthConfig(socialAuthConfiguration);
-            String redirectURL = manager.getAuthenticationUrl(provider.getProviderName(), getURL(pluginSettings.getServerBaseURL()), Permission.AUTHENTICATE_ONLY);
-
+            String redirectURL = manager.getAuthenticationUrl(provider.getProviderName(), getURL(pluginSettings.getServerBaseURL()), perm);
             store(manager);
 
             Map<String, String> responseHeaders = new HashMap<String, String>();
@@ -266,7 +271,7 @@ public class OAuthLoginPlugin implements GoPlugin {
         }
     }
 
-    private void store(SocialAuthManager socialAuthManager) {
+    private void  store(SocialAuthManager socialAuthManager) {
         Map<String, Object> requestMap = new HashMap<String, Object>();
         requestMap.put("plugin-id", provider.getPluginId());
         Map<String, Object> sessionData = new HashMap<String, Object>();

--- a/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
+++ b/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
@@ -208,9 +208,8 @@ public class OAuthLoginPlugin implements GoPlugin {
             oauthConsumerProperties.put(provider.getConsumerKeyPropertyName(), pluginSettings.getConsumerKey());
             oauthConsumerProperties.put(provider.getConsumerSecretPropertyName(), pluginSettings.getConsumerSecret());
             String scopeprop = provider.getAuthScopePropertyName();
-            Permission perm = Permission.AUTHENTICATE_ONLY;
+            Permission perm = provider.getAuthPermission();
             if ( scopeprop != null && scopeprop.length() > 0 ) {
-                perm = Permission.CUSTOM;
                 oauthConsumerProperties.put(provider.getAuthScopePropertyName(), provider.getAuthScopePropertyValue());
             }
             SocialAuthConfig socialAuthConfiguration = SocialAuthConfig.getDefault();

--- a/src/main/java/com/tw/go/plugin/User.java
+++ b/src/main/java/com/tw/go/plugin/User.java
@@ -20,7 +20,7 @@ public class User {
     }
 
     public String getDisplayName() {
-        return displayName;
+        return displayName != null && displayName.length() > 0 ? displayName: username;
     }
 
     public void setDisplayName(String displayName) {

--- a/src/main/java/com/tw/go/plugin/provider/Provider.java
+++ b/src/main/java/com/tw/go/plugin/provider/Provider.java
@@ -19,9 +19,14 @@ public interface Provider {
 
     public String getConsumerSecretPropertyName();
 
+    public String getAuthScopePropertyName();
+
+    public String getAuthScopePropertyValue();
+
     public User getUser(Profile profile);
 
     public List<User> searchUser(PluginSettings pluginSettings, String searchTerm);
 
     public boolean authorize(PluginSettings pluginSettings, User user);
+
 }

--- a/src/main/java/com/tw/go/plugin/provider/Provider.java
+++ b/src/main/java/com/tw/go/plugin/provider/Provider.java
@@ -2,6 +2,7 @@ package com.tw.go.plugin.provider;
 
 import com.tw.go.plugin.PluginSettings;
 import com.tw.go.plugin.User;
+import org.brickred.socialauth.Permission;
 import org.brickred.socialauth.Profile;
 
 import java.util.List;
@@ -22,6 +23,8 @@ public interface Provider {
     public String getAuthScopePropertyName();
 
     public String getAuthScopePropertyValue();
+
+    public Permission getAuthPermission();
 
     public User getUser(Profile profile);
 

--- a/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
+++ b/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
@@ -6,6 +6,7 @@ import com.tw.go.plugin.User;
 import com.tw.go.plugin.provider.Provider;
 import com.tw.go.plugin.util.ImageReader;
 import org.apache.commons.lang.StringUtils;
+import org.brickred.socialauth.Permission;
 import org.brickred.socialauth.Profile;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHUser;
@@ -44,7 +45,10 @@ public class GitHubProvider implements Provider {
     public String getConsumerKeyPropertyName() {
         return "api.github.com.consumer_key";
     }
-
+    @Override
+    public Permission getAuthPermission(){
+        return Permission.CUSTOM;
+    }
     @Override
     public String getAuthScopePropertyName() {
         return "api.github.com.custom_permissions";

--- a/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
+++ b/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
@@ -46,6 +46,16 @@ public class GitHubProvider implements Provider {
     }
 
     @Override
+    public String getAuthScopePropertyName() {
+        return "api.github.com.custom_permissions";
+    }
+
+    @Override
+    public String getAuthScopePropertyValue() {
+        return "read:org, user:email";
+    }
+
+    @Override
     public String getConsumerSecretPropertyName() {
         return "api.github.com.consumer_secret";
     }

--- a/src/main/java/com/tw/go/plugin/provider/google/GoogleProvider.java
+++ b/src/main/java/com/tw/go/plugin/provider/google/GoogleProvider.java
@@ -5,6 +5,7 @@ import com.tw.go.plugin.User;
 import com.tw.go.plugin.provider.Provider;
 import com.tw.go.plugin.util.ImageReader;
 import com.tw.go.plugin.util.RegexUtils;
+import org.brickred.socialauth.Permission;
 import org.brickred.socialauth.Profile;
 
 import java.util.List;
@@ -50,6 +51,9 @@ public class GoogleProvider implements Provider {
 
     @Override
     public String getAuthScopePropertyValue() { return ""; }
+
+    @Override
+    public Permission getAuthPermission() { return Permission.AUTHENTICATE_ONLY; }
 
     @Override
     public User getUser(Profile profile) {

--- a/src/main/java/com/tw/go/plugin/provider/google/GoogleProvider.java
+++ b/src/main/java/com/tw/go/plugin/provider/google/GoogleProvider.java
@@ -44,6 +44,14 @@ public class GoogleProvider implements Provider {
     }
 
     @Override
+    public String getAuthScopePropertyName() {
+        return "";
+    }
+
+    @Override
+    public String getAuthScopePropertyValue() { return ""; }
+
+    @Override
     public User getUser(Profile profile) {
         String emailId = profile.getEmail();
         String fullName = profile.getFullName();


### PR DESCRIPTION
Fixes for: 
 https://github.com/gocd/gocd/issues/1918 - default to `username` if `displayName` isn't set
 https://github.com/gocd-contrib/gocd-oauth-login/issues/22 - reduce scope from `user,user:email` to `read:org,user:email`
