### PR TITLE
Enable users to authenticate using GitHub enterprise

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -4,7 +4,7 @@ dependencies {
   compileOnly(group: 'cd.go.plugin', name: 'go-plugin-api', version: '16.4.0')
 
   compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
-  compile group: 'org.brickred', name: 'socialauth', version: '4.11'
+  compile group: 'org.brickred', name: 'socialauth', version: '4.14'
   compile group: 'commons-io', name: 'commons-io', version: '2.5'
   compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
 

--- a/base/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
+++ b/base/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
@@ -36,6 +36,7 @@ public class OAuthLoginPlugin implements GoPlugin {
     public static final String PLUGIN_SETTINGS_USERNAME = "username";
     public static final String PLUGIN_SETTINGS_PASSWORD = "password";
     public static final String PLUGIN_SETTINGS_OAUTH_TOKEN = "oauth_token";
+    public static final String PLUGIN_SETTINGS_ENTERPRISE = "enterprise";
     public static final String PLUGIN_SETTINGS_AUTHORIZE_URL = "authorize_url";
     public static final String PLUGIN_SETTINGS_ACCESS_TOKEN_URL = "access_token_url";
     public static final String PLUGIN_SETTINGS_API_URL = "api_url";

--- a/base/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
+++ b/base/src/main/java/com/tw/go/plugin/OAuthLoginPlugin.java
@@ -36,6 +36,9 @@ public class OAuthLoginPlugin implements GoPlugin {
     public static final String PLUGIN_SETTINGS_USERNAME = "username";
     public static final String PLUGIN_SETTINGS_PASSWORD = "password";
     public static final String PLUGIN_SETTINGS_OAUTH_TOKEN = "oauth_token";
+    public static final String PLUGIN_SETTINGS_AUTHORIZE_URL = "authorize_url";
+    public static final String PLUGIN_SETTINGS_ACCESS_TOKEN_URL = "access_token_url";
+    public static final String PLUGIN_SETTINGS_API_URL = "api_url";
     @Deprecated
     public static final String PLUGIN_SETTINGS_USERNAME_REGEX = "username_regex";
     public static final String PLUGIN_SETTINGS_ALLOWED_DOMAINS = "allowed_domains";

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def gitRevision = { ->
 
 allprojects {
   group = 'cd.go.contrib.authentication.oauth'
-  version = '2.1'
+  version = '2.2'
   rootProject.ext.gitRevision = gitRevision()
 
   repositories {

--- a/github/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
+++ b/github/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
@@ -96,6 +96,15 @@ public class GitHubProvider implements Provider<GithubPluginSettings> {
         Properties properties = new Properties();
         properties.put("api.github.com.consumer_key", pluginSettings.getConsumerKey());
         properties.put("api.github.com.consumer_secret", pluginSettings.getConsumerSecret());
+        if (isNotBlank(pluginSettings.getAuthorizeUrl())) {
+            properties.put("api.github.com.authentication_url", pluginSettings.getAuthorizeUrl());
+        }
+        if (isNotBlank(pluginSettings.getAccessTokenUrl())) {
+            properties.put("api.github.com.access_token_url", pluginSettings.getAccessTokenUrl());
+        }
+        if (isNotBlank(pluginSettings.getApiUrl())) {
+            properties.put("api.github.com.custom.apiURL", pluginSettings.getApiUrl());
+        }
         if (isNotBlank(pluginSettings.getGithubOrg())) {
             properties.put("api.github.com.custom_permissions", "user:email, read:org");
         } else {
@@ -106,10 +115,12 @@ public class GitHubProvider implements Provider<GithubPluginSettings> {
 
     @Override
     public GithubPluginSettings pluginSettings(Map<String, String> responseBodyMap) {
-        return new GithubPluginSettings(responseBodyMap.get(PLUGIN_SETTINGS_SERVER_BASE_URL), responseBodyMap.get(PLUGIN_SETTINGS_CONSUMER_KEY),
+        return new GithubPluginSettings(
+                responseBodyMap.get(PLUGIN_SETTINGS_SERVER_BASE_URL), responseBodyMap.get(PLUGIN_SETTINGS_CONSUMER_KEY),
                 responseBodyMap.get(PLUGIN_SETTINGS_CONSUMER_SECRET), responseBodyMap.get(PLUGIN_SETTINGS_USERNAME),
                 responseBodyMap.get(PLUGIN_SETTINGS_PASSWORD), responseBodyMap.get(PLUGIN_SETTINGS_OAUTH_TOKEN),
-                responseBodyMap.get(PLUGIN_SETTINGS_ORG_NAME)
+                responseBodyMap.get(PLUGIN_SETTINGS_ORG_NAME), responseBodyMap.get(PLUGIN_SETTINGS_AUTHORIZE_URL),
+                responseBodyMap.get(PLUGIN_SETTINGS_ACCESS_TOKEN_URL), responseBodyMap.get(PLUGIN_SETTINGS_API_URL)
         );
     }
 
@@ -131,11 +142,30 @@ public class GitHubProvider implements Provider<GithubPluginSettings> {
 
     private GitHub getGitHub(GithubPluginSettings pluginSettings) throws IOException {
         GitHub github = null;
-        if (pluginSettings.containsUsernameAndPassword()) {
-            github = GitHub.connectUsingPassword(pluginSettings.getUsername(), pluginSettings.getPassword());
-        } else if (pluginSettings.containsOAuthToken()) {
-            github = GitHub.connectUsingOAuth(pluginSettings.getOauthToken());
+        // Connect to either enterprise github server or public github
+        if (pluginSettings.getApiUrl().isEmpty()) {
+            if (pluginSettings.containsUsernameAndPassword()) {
+                LOGGER.debug("Create Github connection to public Github using username and password");
+                github = GitHub.connectUsingPassword(pluginSettings.getUsername(), pluginSettings.getPassword());
+            } else if (pluginSettings.containsOAuthToken()) {
+                LOGGER.debug("Create Github connection to public Github with token");
+                github = GitHub.connectUsingOAuth(pluginSettings.getOauthToken());
+            }
         }
+        else {
+            if (pluginSettings.containsUsernameAndPassword()) {
+                LOGGER.debug("Create Github connection to enterprise Github using username and password");
+                github = GitHub.connectToEnterprise(
+                    pluginSettings.getApiUrl(),
+                    pluginSettings.getUsername(),
+                    pluginSettings.getPassword()
+                );
+            } else if (pluginSettings.containsOAuthToken()) {
+                LOGGER.debug("Create Github connection to enterprise Github with token");
+                github = GitHub.connectToEnterprise(pluginSettings.getApiUrl(), pluginSettings.getOauthToken());
+            }
+        }
+
         if (github == null) {
             throw new RuntimeException("Plugin not configured. Please provide plugin settings.");
         }

--- a/github/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
+++ b/github/src/main/java/com/tw/go/plugin/provider/github/GitHubProvider.java
@@ -96,13 +96,9 @@ public class GitHubProvider implements Provider<GithubPluginSettings> {
         Properties properties = new Properties();
         properties.put("api.github.com.consumer_key", pluginSettings.getConsumerKey());
         properties.put("api.github.com.consumer_secret", pluginSettings.getConsumerSecret());
-        if (isNotBlank(pluginSettings.getAuthorizeUrl())) {
+        if (pluginSettings.isEnterprise()) {
             properties.put("api.github.com.authentication_url", pluginSettings.getAuthorizeUrl());
-        }
-        if (isNotBlank(pluginSettings.getAccessTokenUrl())) {
             properties.put("api.github.com.access_token_url", pluginSettings.getAccessTokenUrl());
-        }
-        if (isNotBlank(pluginSettings.getApiUrl())) {
             properties.put("api.github.com.custom.apiURL", pluginSettings.getApiUrl());
         }
         if (isNotBlank(pluginSettings.getGithubOrg())) {
@@ -119,8 +115,9 @@ public class GitHubProvider implements Provider<GithubPluginSettings> {
                 responseBodyMap.get(PLUGIN_SETTINGS_SERVER_BASE_URL), responseBodyMap.get(PLUGIN_SETTINGS_CONSUMER_KEY),
                 responseBodyMap.get(PLUGIN_SETTINGS_CONSUMER_SECRET), responseBodyMap.get(PLUGIN_SETTINGS_USERNAME),
                 responseBodyMap.get(PLUGIN_SETTINGS_PASSWORD), responseBodyMap.get(PLUGIN_SETTINGS_OAUTH_TOKEN),
-                responseBodyMap.get(PLUGIN_SETTINGS_ORG_NAME), responseBodyMap.get(PLUGIN_SETTINGS_AUTHORIZE_URL),
-                responseBodyMap.get(PLUGIN_SETTINGS_ACCESS_TOKEN_URL), responseBodyMap.get(PLUGIN_SETTINGS_API_URL)
+                responseBodyMap.get(PLUGIN_SETTINGS_ORG_NAME), responseBodyMap.containsKey(PLUGIN_SETTINGS_ENTERPRISE),
+                responseBodyMap.get(PLUGIN_SETTINGS_AUTHORIZE_URL), responseBodyMap.get(PLUGIN_SETTINGS_ACCESS_TOKEN_URL),
+                responseBodyMap.get(PLUGIN_SETTINGS_API_URL)
         );
     }
 
@@ -143,32 +140,41 @@ public class GitHubProvider implements Provider<GithubPluginSettings> {
     private GitHub getGitHub(GithubPluginSettings pluginSettings) throws IOException {
         GitHub github = null;
         // Connect to either enterprise github server or public github
-        if (pluginSettings.getApiUrl().isEmpty()) {
-            if (pluginSettings.containsUsernameAndPassword()) {
-                LOGGER.debug("Create Github connection to public Github using username and password");
-                github = GitHub.connectUsingPassword(pluginSettings.getUsername(), pluginSettings.getPassword());
-            } else if (pluginSettings.containsOAuthToken()) {
-                LOGGER.debug("Create Github connection to public Github with token");
-                github = GitHub.connectUsingOAuth(pluginSettings.getOauthToken());
-            }
-        }
-        else {
-            if (pluginSettings.containsUsernameAndPassword()) {
-                LOGGER.debug("Create Github connection to enterprise Github using username and password");
-                github = GitHub.connectToEnterprise(
-                    pluginSettings.getApiUrl(),
-                    pluginSettings.getUsername(),
-                    pluginSettings.getPassword()
-                );
-            } else if (pluginSettings.containsOAuthToken()) {
-                LOGGER.debug("Create Github connection to enterprise Github with token");
-                github = GitHub.connectToEnterprise(pluginSettings.getApiUrl(), pluginSettings.getOauthToken());
-            }
+        if (pluginSettings.isEnterprise()) {
+            github = connectToEnterpriseGitHub(pluginSettings);
+        } else {
+            github = connectToPublicGitHub(pluginSettings);
         }
 
         if (github == null) {
             throw new RuntimeException("Plugin not configured. Please provide plugin settings.");
         }
         return github;
+    }
+
+    private GitHub connectToPublicGitHub(GithubPluginSettings pluginSettings) throws IOException {
+        if (pluginSettings.containsUsernameAndPassword()) {
+            LOGGER.debug("Create GitHub connection to public GitHub using username and password");
+            return GitHub.connectUsingPassword(pluginSettings.getUsername(), pluginSettings.getPassword());
+        } else if (pluginSettings.containsOAuthToken()) {
+            LOGGER.debug("Create GitHub connection to public GitHub with token");
+            return GitHub.connectUsingOAuth(pluginSettings.getOauthToken());
+        }
+        return null;
+    }
+
+    private GitHub connectToEnterpriseGitHub(GithubPluginSettings pluginSettings) throws IOException {
+        if (pluginSettings.containsUsernameAndPassword()) {
+            LOGGER.debug("Create GitHub connection to enterprise GitHub using username and password");
+            return GitHub.connectToEnterprise(
+                    pluginSettings.getApiUrl(),
+                    pluginSettings.getUsername(),
+                    pluginSettings.getPassword()
+            );
+        } else if (pluginSettings.containsOAuthToken()) {
+            LOGGER.debug("Create GitHub connection to enterprise GitHub with token");
+            return GitHub.connectToEnterprise(pluginSettings.getApiUrl(), pluginSettings.getOauthToken());
+        }
+        return null;
     }
 }

--- a/github/src/main/java/com/tw/go/plugin/provider/github/GithubPluginSettings.java
+++ b/github/src/main/java/com/tw/go/plugin/provider/github/GithubPluginSettings.java
@@ -9,13 +9,30 @@ public class GithubPluginSettings extends PluginSettings {
     private String username;
     private String password;
     private String oauthToken;
+    private String authorizeUrl;
+    private String accessTokenUrl;
+    private String apiUrl;
 
-    public GithubPluginSettings(String serverBaseURL, String consumerKey, String consumerSecret, String username, String password, String oauthToken, String githubOrg) {
+    public GithubPluginSettings(
+            String serverBaseURL,
+            String consumerKey,
+            String consumerSecret,
+            String username,
+            String password,
+            String oauthToken,
+            String githubOrg,
+            String authorizeUrl,
+            String accessTokenUrl,
+            String apiUrl
+    ) {
         super(serverBaseURL, consumerKey, consumerSecret);
         this.username = username;
         this.password = password;
         this.oauthToken = oauthToken;
         this.githubOrg = githubOrg;
+        this.authorizeUrl = authorizeUrl;
+        this.accessTokenUrl = accessTokenUrl;
+        this.apiUrl = apiUrl;
     }
 
     public String getGithubOrg() {
@@ -52,5 +69,17 @@ public class GithubPluginSettings extends PluginSettings {
 
     public boolean containsOAuthToken() {
         return !isBlank(oauthToken);
+    }
+
+    public String getAuthorizeUrl() {
+        return authorizeUrl;
+    }
+
+    public String getAccessTokenUrl() {
+        return accessTokenUrl;
+    }
+
+    public String getApiUrl() {
+        return apiUrl;
     }
 }

--- a/github/src/main/java/com/tw/go/plugin/provider/github/GithubPluginSettings.java
+++ b/github/src/main/java/com/tw/go/plugin/provider/github/GithubPluginSettings.java
@@ -9,6 +9,7 @@ public class GithubPluginSettings extends PluginSettings {
     private String username;
     private String password;
     private String oauthToken;
+    private Boolean enterprise;
     private String authorizeUrl;
     private String accessTokenUrl;
     private String apiUrl;
@@ -21,6 +22,7 @@ public class GithubPluginSettings extends PluginSettings {
             String password,
             String oauthToken,
             String githubOrg,
+            Boolean enterprise,
             String authorizeUrl,
             String accessTokenUrl,
             String apiUrl
@@ -30,6 +32,7 @@ public class GithubPluginSettings extends PluginSettings {
         this.password = password;
         this.oauthToken = oauthToken;
         this.githubOrg = githubOrg;
+        this.enterprise = enterprise;
         this.authorizeUrl = authorizeUrl;
         this.accessTokenUrl = accessTokenUrl;
         this.apiUrl = apiUrl;
@@ -69,6 +72,10 @@ public class GithubPluginSettings extends PluginSettings {
 
     public boolean containsOAuthToken() {
         return !isBlank(oauthToken);
+    }
+
+    public boolean isEnterprise() {
+        return enterprise;
     }
 
     public String getAuthorizeUrl() {

--- a/github/src/main/resources/plugin-settings.template.html
+++ b/github/src/main/resources/plugin-settings.template.html
@@ -29,6 +29,21 @@
     <span class="form_error" ng-show="GOINPUTNAME[oauth_token].$error.server">{{ GOINPUTNAME[oauth_token].$error.server }}</span>
 </div>
 <div class="form_item_block">
+    <label>GitHub Authorization Url:</label>
+    <input type="text" ng-model="authorize_url" ng-required="true" placeholder="https://github.com/login/oauth/authorize"/>
+    <span class="form_error" ng-show="GOINPUTNAME[authorize_url].$error.server">{{ GOINPUTNAME[authorize_url].$error.server }}</span>
+</div>
+<div class="form_item_block">
+    <label>GitHub Access Token Url:</label>
+    <input type="text" ng-model="access_token_url" ng-required="true" placeholder="https://github.com/login/oauth/access_token"/>
+    <span class="form_error" ng-show="GOINPUTNAME[access_token_url].$error.server">{{ GOINPUTNAME[access_token_url].$error.server }}</span>
+</div>
+<div class="form_item_block">
+    <label>GitHub API Url:</label>
+    <input type="text" ng-model="api_url" ng-required="true" placeholder="https://github.com/api/v3"/>
+    <span class="form_error" ng-show="GOINPUTNAME[api_url].$error.server">{{ GOINPUTNAME[api_url].$error.server }}</span>
+</div>
+<div class="form_item_block">
     <label>Github Organization Name (requires you to provide a username and either a password or oauth token):</label>
     <input type="text" ng-model="organization_name" ng-required="true"/>
     <span class="form_error" ng-show="GOINPUTNAME[organization_name].$error.server">{{ GOINPUTNAME[organization_name].$error.server }}</span>

--- a/github/src/main/resources/plugin-settings.template.html
+++ b/github/src/main/resources/plugin-settings.template.html
@@ -29,22 +29,26 @@
     <span class="form_error" ng-show="GOINPUTNAME[oauth_token].$error.server">{{ GOINPUTNAME[oauth_token].$error.server }}</span>
 </div>
 <div class="form_item_block">
-    <label>GitHub Authorization Url:</label>
-    <input type="text" ng-model="authorize_url" ng-required="true" placeholder="https://github.com/login/oauth/authorize"/>
+    <label>GitHub Enterprise:</label>
+    <input type="checkbox" ng-model="enterprise" ng-true-value="on"/>
+</div>
+<div class="form_item_block" ng-show="enterprise">
+    <label>GitHub Authorization Url <span class="asterisk">*</span>:</label>
+    <input type="text" ng-model="authorize_url" ng-required="true" placeholder="https://github.company.com/login/oauth/authorize"/>
     <span class="form_error" ng-show="GOINPUTNAME[authorize_url].$error.server">{{ GOINPUTNAME[authorize_url].$error.server }}</span>
 </div>
-<div class="form_item_block">
-    <label>GitHub Access Token Url:</label>
-    <input type="text" ng-model="access_token_url" ng-required="true" placeholder="https://github.com/login/oauth/access_token"/>
+<div class="form_item_block" ng-show="enterprise">
+    <label>GitHub Access Token Url <span class="asterisk">*</span>:</label>
+    <input type="text" ng-model="access_token_url" ng-required="true" placeholder="https://github.company.com/login/oauth/access_token"/>
     <span class="form_error" ng-show="GOINPUTNAME[access_token_url].$error.server">{{ GOINPUTNAME[access_token_url].$error.server }}</span>
 </div>
-<div class="form_item_block">
-    <label>GitHub API Url:</label>
-    <input type="text" ng-model="api_url" ng-required="true" placeholder="https://github.com/api/v3"/>
+<div class="form_item_block" ng-show="enterprise">
+    <label>GitHub API Url <span class="asterisk">*</span>:</label>
+    <input type="text" ng-model="api_url" ng-required="true" placeholder="https://github.company.com/api/v3"/>
     <span class="form_error" ng-show="GOINPUTNAME[api_url].$error.server">{{ GOINPUTNAME[api_url].$error.server }}</span>
 </div>
 <div class="form_item_block">
-    <label>Github Organization Name (requires you to provide a username and either a password or oauth token):</label>
+    <label>GitHub Organization Name (requires you to provide a username and either a password or oauth token):</label>
     <input type="text" ng-model="organization_name" ng-required="true"/>
     <span class="form_error" ng-show="GOINPUTNAME[organization_name].$error.server">{{ GOINPUTNAME[organization_name].$error.server }}</span>
 </div>


### PR DESCRIPTION
With merging and releasing my PR on the socialauth plugin https://github.com/3pillarlabs/socialauth/pull/95 it is possible to connect to an GitHub Enterprise server. With these PR I enable the users to authenticate on there GoCD servers via GitHub Enterprise. To do that they have to specify the access_token_url, authorize_url and api_url in the plugin configuration. If they are leaved blank the default public github urls are used.